### PR TITLE
feat(Codec): zero-copy conversion for from/to bytes functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 0.4.0
 
+- Improved the performance of the `Codec` by implementing zero-copy conversion for `from_bytes` and `to_bytes` functions.
 - Adding `remove` method for `StorageBST`
 
 ## Version 0.3.0

--- a/crates/kelk/src/lib.rs
+++ b/crates/kelk/src/lib.rs
@@ -17,7 +17,6 @@
     unused_comparisons,
     unused_parens,
     while_true,
-    trivial_casts,
     trivial_numeric_casts
 )]
 


### PR DESCRIPTION
## Description

Improved the performance of the `Codec` by implementing zero-copy conversion for `from_bytes` and `to_bytes` functions.


## Checklist
<!--- What types of changes does your code introduce?
Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] CHANGELOG is updated.
